### PR TITLE
Add outbound shipment order cancel job

### DIFF
--- a/app/helpers/quiet_logistics_helper.rb
+++ b/app/helpers/quiet_logistics_helper.rb
@@ -15,6 +15,30 @@ module QuietLogisticsHelper
     end
   end
 
+  def shipment_order_cancel(shipment)
+    if shipment.ql_cancellation_date.present?
+      element(
+        class: 'ql-shipment-order-cancel',
+        complete: true,
+        label: t('quiet_logistics.admin.shipment_order_cancel.cancellation_label'),
+      ) do
+        t('quiet_logistics.admin.shipment_order_cancel.cancellation_date', cancellation_date: pretty_time(shipment.ql_cancellation_date))
+      end
+    else
+      element(
+        class: 'ql-shipment-order-cancel',
+        complete: shipment.ql_cancellation_sent.present?,
+        label: t('quiet_logistics.admin.shipment_order_cancel.sent_label'),
+      ) do
+        if shipment.ql_cancellation_sent.present?
+          t('quiet_logistics.admin.shipment_order_cancel.sent', cancellation_date: pretty_time(shipment.ql_cancellation_sent))
+        else
+          t('quiet_logistics.admin.shipment_order_cancel.not_sent')
+        end
+      end
+    end
+  end
+
   private
 
   def element(**args, &_block)

--- a/app/jobs/solidus_quiet_logistics/outbound/push_shipment_order_cancel_document_job.rb
+++ b/app/jobs/solidus_quiet_logistics/outbound/push_shipment_order_cancel_document_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SolidusQuietLogistics
+  module Outbound
+    class PushShipmentOrderCancelDocumentJob < ActiveJob::Base
+      queue_as :default
+
+      def perform(shipment)
+        return unless SolidusQuietLogistics.configuration.enabled&.call(shipment.order)
+
+        SolidusQuietLogistics::Outbound::Document::ShipmentOrderCancel.new(shipment).process
+      rescue SolidusQuietLogistics::Outbound::Document::ShipmentOrderCancel::CancellationAlreadySent
+        Rails.logger.info "QL cancellation already sent for shipment #{shipment.id}"
+      end
+    end
+  end
+end

--- a/app/overrides/spree/admin/orders/_shipment/add_ql_information.html.erb.deface
+++ b/app/overrides/spree/admin/orders/_shipment/add_ql_information.html.erb.deface
@@ -7,5 +7,6 @@
     </legend>
     <dl class="ql-info">
       <%= shipment_order(shipment) %>
+      <%= shipment_order_cancel(shipment) %>
   </fieldset>
 <% end %>

--- a/app/overrides/spree/admin/orders/_shipment/add_remove_shipment_button.html.erb.deface
+++ b/app/overrides/spree/admin/orders/_shipment/add_remove_shipment_button.html.erb.deface
@@ -1,0 +1,10 @@
+<!-- insert_after "table.shipment" -->
+
+<% if SolidusQuietLogistics.configuration.enabled&.call(@order) %>
+  <% if !shipment.shipped? && !shipment.canceled? && shipment.pushed? %>
+    <% if shipment.ql_cancellation_sent.blank? && shipment.ql_cancellation_date.blank? %>
+      <%= button_to "#{Spree.t('actions.delete')} #{Spree.t(:shipment)}", admin_shipment_path(shipment),
+        method: :delete, remote: true, class: 'btn btn-primary delete-shipment js-delete-shipment-hook' %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/overrides/spree/admin/orders/_shipment/remove_ship_shipment_button.html.erb.deface
+++ b/app/overrides/spree/admin/orders/_shipment/remove_ship_shipment_button.html.erb.deface
@@ -1,0 +1,5 @@
+<!-- surround "erb[silent]:contains('shipment.ready? && can?(:ship, shipment)')" -->
+
+<% unless SolidusQuietLogistics.configuration.enabled&.call(@order) %>
+  <%= render_original %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,5 +11,14 @@ en:
     admin:
       sending: 'Sending to QL...'
       shipment_order:
+        label: Outbound shipment order pushed?
+        pushed: Pushed to QL
+        not_pushed: Not Pushed to QL
         push_to_ql: Push shipment order
         pending: Shipment order document will be sent to QL
+      shipment_order_cancel:
+        sent_label: Outbound shipment order cancel sent?
+        cancellation_label: Shipment order cancellation date by QL
+        sent: Cancellation sent at %{cancellation_date}
+        cancellation_date: Cancellation received at %{cancellation_date}
+        not_sent: Cancellation not sent

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Spree::Core::Engine.routes.draw do
   namespace :admin do
-    resources :shipments, only: [] do
+    resources :shipments, only: :destroy do
       member do
         post :push_shipment_order
       end

--- a/db/migrate/20190211133532_add_ql_cancellation_field_to_spree_shipment.rb
+++ b/db/migrate/20190211133532_add_ql_cancellation_field_to_spree_shipment.rb
@@ -1,0 +1,6 @@
+class AddQlCancellationFieldToSpreeShipment < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_shipments, :ql_cancellation_sent, :datetime
+    add_column :spree_shipments, :ql_cancellation_date, :datetime
+  end
+end

--- a/lib/solidus_quiet_logistics/outbound/document/shipment_order_cancel.rb
+++ b/lib/solidus_quiet_logistics/outbound/document/shipment_order_cancel.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module SolidusQuietLogistics
+  module Outbound
+    class Document < SolidusQuietLogistics::Document
+      class ShipmentOrderCancel < SolidusQuietLogistics::Outbound::Document
+        attr_reader :shipment
+
+        class << self
+          def document_type
+            'ShipmentOrderCancel'
+          end
+        end
+
+        def initialize(shipment)
+          @shipment = shipment
+        end
+
+        def to_xml
+          Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
+            xml.ShipmentOrderCancel(
+              xmlns: 'http://schemas.quietlogistics.com/V2/ShipmentOrderCancel.xsd',
+              'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+              'xsi:schemaLocation': 'http://schemas.quietlogistics.com/V2/ShipmentOrderCancel.xsd schema.xsd',
+              ClientId: SolidusQuietLogistics.configuration.client_id,
+              BusinessUnit: SolidusQuietLogistics.configuration.business_unit,
+              OrderNumber: shipment.number,
+            )
+          end.to_xml
+        end
+
+        def process
+          super
+
+          shipment.update(ql_cancellation_sent: Time.zone.now)
+        end
+
+        private
+
+        def validate_context
+          fail NotPushedError unless shipment.pushed?
+          fail CancellationAlreadySent if shipment.ql_cancellation_sent.present?
+        end
+
+        def document_name
+          [
+            SolidusQuietLogistics.configuration.client_id,
+            self.class.document_type,
+            shipment.number,
+            shipment.created_at.strftime('%Y%m%d'),
+            shipment.created_at.strftime('%H%M%S'),
+          ].join('_').concat('.xml')
+        end
+
+        NotPushedError = Class.new(SolidusQuietLogistics::Outbound::Error::ServiceError)
+        CancellationAlreadySent = Class.new(SolidusQuietLogistics::Outbound::Error::ServiceError)
+      end
+    end
+  end
+end

--- a/spec/features/admin/order/push_shipment_order_spec.rb
+++ b/spec/features/admin/order/push_shipment_order_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Push shipment order', type: :feature, js: true do
   include Warden::Test::Helpers
   include Spree::BaseHelper
 
+  let!(:store) { create(:store) }
   let(:admin_user) { create(:admin_user) }
 
   before do

--- a/spec/jobs/solidus_quiet_logistics/outbound/push_shipment_order_cancel_document_job_spec.rb
+++ b/spec/jobs/solidus_quiet_logistics/outbound/push_shipment_order_cancel_document_job_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusQuietLogistics::Outbound::PushShipmentOrderCancelDocumentJob do
+  subject { -> { described_class.perform_now(shipment) } }
+
+  let(:order) { create(:order_with_line_items) }
+  let(:shipment) { order.shipments.first }
+
+  let(:shipment_order_cancel) do
+    instance_spy('SolidusQuietLogistics::Outbound::Document::ShipmentOrderCancel')
+  end
+
+  before do
+    allow(SolidusQuietLogistics::Outbound::Document::ShipmentOrderCancel).to receive(:new)
+      .with(shipment)
+      .and_return(shipment_order_cancel)
+  end
+
+  it 'processes the order' do
+    subject.call
+
+    expect(shipment_order_cancel).to have_received(:process)
+  end
+end

--- a/spec/solidus_quiet_logistics/outbound/document/shipment_order_cancel_spec.rb
+++ b/spec/solidus_quiet_logistics/outbound/document/shipment_order_cancel_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusQuietLogistics::Outbound::Document::ShipmentOrderCancel do
+  include_context 'quiet_logistics_outbound_document'
+
+  subject(:document) { described_class.new(shipment) }
+
+  let(:shipment) { create(:shipment, pushed: true) }
+
+  describe '#process' do
+    it 'changes the ql_cancellation_sent timestamp' do
+      document.process
+
+      expect(shipment.ql_cancellation_sent.present?).to eq(true)
+    end
+
+    context 'when shipment wasn\'t pushed' do
+      before { shipment.update(pushed: false) }
+
+      it 'fails with invalid shipping method error' do
+        expect { document.process }.to raise_error(SolidusQuietLogistics::Outbound::Document::ShipmentOrderCancel::NotPushedError)
+      end
+    end
+
+    context 'when shipment cancellation already sent' do
+      before { shipment.update(ql_cancellation_sent: Time.now) }
+
+      it 'fails with shipment cancellation already sent' do
+        expect { document.process }.to raise_error(SolidusQuietLogistics::Outbound::Document::ShipmentOrderCancel::CancellationAlreadySent)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref: #5 
---

| Issue | Migrations? |
| -- | -- |
| #5  |  👍 |

Add the outbound shipment order cancel job to push the SO cancel document on S3.

### Integration
Call the job when delete shipment button is triggered from the admin.
