### PR TITLE
Inbound Shipment Order Cancel

### DIFF
--- a/app/decorators/models/spree/order/override_after_cancel.rb
+++ b/app/decorators/models/spree/order/override_after_cancel.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusQuietLogistics
+  module Orders
+    module OverrideAfterCancel
+      def after_cancel
+        payments.completed.each(&:cancel!)
+        payments.store_credits.pending.each(&:void_transaction!)
+        recalculate
+      end
+
+      Spree::Order.prepend self
+    end
+  end
+end

--- a/app/mailers/solidus_quiet_logistics/inbound/base_mailer.rb
+++ b/app/mailers/solidus_quiet_logistics/inbound/base_mailer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusQuietLogistics
+  module Inbound
+    class BaseMailer < Spree::BaseMailer
+      helper ApplicationHelper
+
+      private
+
+      def support_email
+        SolidusQuietLogistics.configuration.support_email
+      end
+    end
+  end
+end

--- a/app/mailers/solidus_quiet_logistics/inbound/shipment_order_cancel_mailer.rb
+++ b/app/mailers/solidus_quiet_logistics/inbound/shipment_order_cancel_mailer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SolidusQuietLogistics
+  module Inbound
+    class ShipmentOrderCancelMailer < BaseMailer
+      def failed_cancellation(shipment, recipient: support_email)
+        return if support_email.blank?
+
+        @order = shipment.order
+        @shipment = shipment
+
+        mail(
+          to: recipient,
+          from: from_address(Spree::Store.default),
+          subject: t('quiet_logistics.mailers.shipment_cancellation_failed.title'),
+        )
+      end
+
+      def successful_cancellation(shipment, recipient: support_email)
+        return if support_email.blank?
+
+        @order = shipment.order
+        @shipment = shipment
+
+        mail(
+          to: recipient,
+          from: from_address(Spree::Store.default),
+          subject: t('quiet_logistics.mailers.shipment_successfully_cancelled.title'),
+        )
+      end
+    end
+  end
+end

--- a/app/views/solidus_quiet_logistics/inbound/shipment_order_cancel_mailer/failed_cancellation.html.erb
+++ b/app/views/solidus_quiet_logistics/inbound/shipment_order_cancel_mailer/failed_cancellation.html.erb
@@ -1,0 +1,31 @@
+<table>
+  <tr>
+    <td>
+      <p class="lede">
+        <%= t('.dear_customer') %>
+      </p>
+      <p>
+        <%= t('quiet_logistics.mailers.shipment_cancellation_failed.subtitle', shipment_number: @shipment.number) %>
+      </p>
+      <p>
+        <%= t('mailers.your_shipment') %>
+      </p>
+      <table>
+        <% @shipment.line_items.each do |item| %>
+          <tr>
+            <td><%= item.variant.sku %></td>
+            <td>
+              <%= item.variant.product.name %>
+              <%= item.variant.options_text -%>
+            </td>
+            <td>(<%= item.quantity %>) @ <%= item.single_money %> = <%= item.display_amount %></td>
+          </tr>
+        <% end %>
+      </table>
+      <p>
+        <%= t('.thanks') %>
+      </p>
+    </td>
+    <td class="expander"></td>
+  </tr>
+</table>

--- a/app/views/solidus_quiet_logistics/inbound/shipment_order_cancel_mailer/successful_cancellation.html.erb
+++ b/app/views/solidus_quiet_logistics/inbound/shipment_order_cancel_mailer/successful_cancellation.html.erb
@@ -1,0 +1,31 @@
+<table>
+  <tr>
+    <td>
+      <p class="lede">
+        <%= t('.dear_customer') %>
+      </p>
+      <p>
+        <%= t('quiet_logistics.mailers.shipment_successfully_cancelled.subtitle', shipment_number: @shipment.number) %>
+      </p>
+      <p>
+        <%= t('mailers.your_shipment') %>
+      </p>
+      <table>
+        <% @shipment.line_items.each do |item| %>
+          <tr>
+            <td><%= item.variant.sku %></td>
+            <td>
+              <%= item.variant.product.name %>
+              <%= item.variant.options_text -%>
+            </td>
+            <td>(<%= item.quantity %>) @ <%= item.single_money %> = <%= item.display_amount %></td>
+          </tr>
+        <% end %>
+      </table>
+      <p>
+        <%= t('.thanks') %>
+      </p>
+    </td>
+    <td class="expander"></td>
+  </tr>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,3 +22,10 @@ en:
         sent: Cancellation sent at %{cancellation_date}
         cancellation_date: Cancellation received at %{cancellation_date}
         not_sent: Cancellation not sent
+    mailers:
+      shipment_cancellation_failed:
+        title: Shipment cancellation failed
+        subtitle: "We can't cancel your shipment: %{shipment_number}"
+      shipment_successfully_cancelled:
+        title: Shipment successfully cancelled
+        subtitle: "We have cancelled your shipment: %{shipment_number}"

--- a/lib/solidus_quiet_logistics.rb
+++ b/lib/solidus_quiet_logistics.rb
@@ -4,7 +4,7 @@ require 'deface'
 
 class Configuration
   # QL
-  attr_accessor :enabled, :client_id, :business_unit, :warehouse
+  attr_accessor :enabled, :client_id, :business_unit, :warehouse, :support_email
 
   # AWS
   attr_accessor :aws_region, :aws_access_key_id, :aws_secret_access_key,

--- a/lib/solidus_quiet_logistics/inbound/document/shipment_order_cancel_ready.rb
+++ b/lib/solidus_quiet_logistics/inbound/document/shipment_order_cancel_ready.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module SolidusQuietLogistics
+  module Inbound
+    class Document < SolidusQuietLogistics::Document
+      class ShipmentOrderCancelReady < SolidusQuietLogistics::Inbound::Document
+        class << self
+          def from_xml(body)
+            nokogiri = Nokogiri::XML(body)
+
+            new(
+              shipment_number: nokogiri.xpath('//@OrderNumber').first.text,
+              cancellation_status: nokogiri.xpath('//@Status').first.value,
+              date_cancelled: nokogiri.xpath('//@DateCancelled').first.value,
+            )
+          end
+        end
+
+        attr_reader :shipment_number, :cancellation_status, :date_cancelled,
+          :shipment
+
+        def initialize(shipment_number:, cancellation_status:, date_cancelled: Time.now)
+          @shipment_number = shipment_number
+          @date_cancelled = date_cancelled
+          @cancellation_status = cancellation_status
+          @shipment = Spree::Shipment.find_by(number: shipment_number)
+        end
+
+        def process
+          return if shipment&.canceled?
+
+          if cancellation_status == 'SUCCESS'
+            successful_cancellation
+          else
+            failed_cancellation
+          end
+        end
+
+        private
+
+        def failed_cancellation
+          shipment.update(ql_cancellation_sent: nil)
+
+          SolidusQuietLogistics::Inbound::ShipmentOrderCancelMailer
+            .failed_cancellation(shipment, recipient: shipment.order.email)
+            .deliver_later
+          SolidusQuietLogistics::Inbound::ShipmentOrderCancelMailer
+            .failed_cancellation(shipment).deliver_later
+        end
+
+        def successful_cancellation
+          shipment.cancel!
+          shipment.update!(ql_cancellation_date: date_cancelled)
+
+          shipment.order.cancel! if shipment.order.shipments.all?(&:canceled?)
+
+          SolidusQuietLogistics::Inbound::ShipmentOrderCancelMailer
+            .successful_cancellation(shipment, recipient: shipment.order.email)
+            .deliver_later
+          SolidusQuietLogistics::Inbound::ShipmentOrderCancelMailer
+            .successful_cancellation(shipment).deliver_later
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_quiet_logistics/inbound/message_processor.rb
+++ b/lib/solidus_quiet_logistics/inbound/message_processor.rb
@@ -5,8 +5,8 @@ module SolidusQuietLogistics
     class MessageProcessor
       DOCUMENT_CLASSES = {
         'ShipmentOrderResult' => Document::ShipmentOrderResult,
+        'ShipmentOrderCancelReady' => Document::ShipmentOrderCancelReady,
         # 'InventorySummaryReady' => Document::InventorySummaryReady,
-        # 'ShipmentOrderCancelReady' => Document::ShipmentOrderCancelReady,
         # 'RMAResultDocument' => Document::RMAResultDocument,
         # 'ProductConfigurationRequest' => Document::ProductConfigurationRequest,
         # 'PurchaseOrderStartReceipt' => Document::PurchaseOrderStartReceipt,

--- a/solidus_quiet_logistics.gemspec
+++ b/solidus_quiet_logistics.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'factory_bot'
+  s.add_development_dependency 'pry'
 end

--- a/spec/mailers/solidus_quiet_logistics/inbound/shipment_order_cancel_mailer_spec.rb
+++ b/spec/mailers/solidus_quiet_logistics/inbound/shipment_order_cancel_mailer_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusQuietLogistics::Inbound::ShipmentOrderCancelMailer, type: :mailer do
+  let(:shipment) { create(:shipment) }
+  let(:recipient) { shipment.order.email }
+  let(:support_email) { 'support@email.com' }
+
+  before do
+    allow(SolidusQuietLogistics.configuration).to receive(:support_email)
+      .and_return(support_email)
+  end
+
+  describe '.failed_cancellation' do
+    context 'when recipient is defined' do
+      let(:mail) { described_class.failed_cancellation(shipment, recipient: recipient) }
+
+      it 'sends the email to the specified recipient' do
+        expect(mail.to).to eq([recipient])
+      end
+    end
+
+    context 'when recipient is not defined' do
+      let(:mail) { described_class.failed_cancellation(shipment) }
+
+      it 'sends the email to the support email' do
+        expect(mail.to).to eq([support_email])
+      end
+    end
+  end
+
+  describe '.successful_cancellation' do
+    context 'when recipient is defined' do
+      let(:mail) { described_class.successful_cancellation(shipment, recipient: recipient) }
+
+      it 'sends the email to the specified recipient' do
+        expect(mail.to).to eq([recipient])
+      end
+    end
+
+    context 'when recipient is not defined' do
+      let(:mail) { described_class.successful_cancellation(shipment) }
+
+      it 'sends the email to the support email' do
+        expect(mail.to).to eq([support_email])
+      end
+    end
+  end
+end

--- a/spec/solidus_quiet_logistics/inbound/document/shipment_order_cancel_ready_spec.rb
+++ b/spec/solidus_quiet_logistics/inbound/document/shipment_order_cancel_ready_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusQuietLogistics::Inbound::Document::ShipmentOrderCancelReady do
+  describe '#process' do
+    subject(:document) do
+      described_class.new(
+        shipment_number: shipment.number,
+        cancellation_status: cancellation_status,
+        date_cancelled: date_cancelled,
+      )
+    end
+
+    let(:date_cancelled) { Time.now }
+    let(:first_shipment_order_cancel_mailer) { instance_double('ActionMailer::Delivery') }
+    let(:second_shipment_order_cancel_mailer) { instance_double('ActionMailer::Delivery') }
+
+    let(:order) { create(:completed_order_with_totals) }
+    let(:shipment) { order.shipments.first }
+
+    before do
+      create(:shipment, order: order)
+      order.reload
+    end
+
+    context 'when the cancellation was successful' do
+      let(:cancellation_status) { 'SUCCESS' }
+
+      before do
+        order.shipments.each do |shipment|
+          shipment.update!(pushed: true, ql_cancellation_sent: Time.now)
+        end
+
+        allow(SolidusQuietLogistics::Inbound::ShipmentOrderCancelMailer).to receive(:successful_cancellation)
+          .with(shipment, recipient: shipment.order.email)
+          .and_return(first_shipment_order_cancel_mailer)
+
+        allow(SolidusQuietLogistics::Inbound::ShipmentOrderCancelMailer).to receive(:successful_cancellation)
+          .with(shipment)
+          .and_return(second_shipment_order_cancel_mailer)
+      end
+
+      it 'updates shipment ql_cancellation_date timestamp and cancel the shipment' do
+        expect(first_shipment_order_cancel_mailer).to receive(:deliver_later)
+        expect(second_shipment_order_cancel_mailer).to receive(:deliver_later)
+
+        document.process
+
+        shipment.reload
+        expect(shipment.ql_cancellation_date.utc.to_s).to eq(date_cancelled.utc.to_s)
+        expect(shipment.state).to eq('canceled')
+        expect(shipment.order.state).to eq('complete')
+      end
+
+      context 'when all the shipments were canceled' do
+        before { order.shipments.last.cancel! }
+
+        it 'cancels the order' do
+          expect(first_shipment_order_cancel_mailer).to receive(:deliver_later)
+          expect(second_shipment_order_cancel_mailer).to receive(:deliver_later)
+
+          document.process
+
+          shipment.reload
+          expect(shipment.order.state).to eq('canceled')
+        end
+      end
+    end
+
+    context 'when the cancellation fails' do
+      let(:cancellation_status) { 'FAIL' }
+
+      before do
+        allow(SolidusQuietLogistics::Inbound::ShipmentOrderCancelMailer).to receive(:failed_cancellation)
+          .with(shipment, recipient: shipment.order.email)
+          .and_return(first_shipment_order_cancel_mailer)
+
+        allow(SolidusQuietLogistics::Inbound::ShipmentOrderCancelMailer).to receive(:failed_cancellation)
+          .with(shipment)
+          .and_return(second_shipment_order_cancel_mailer)
+      end
+
+      it 'sends the email and clear the ql_cancellation_sent timestamp' do
+        expect(first_shipment_order_cancel_mailer).to receive(:deliver_later)
+        expect(second_shipment_order_cancel_mailer).to receive(:deliver_later)
+
+        document.process
+
+        expect(shipment.ql_cancellation_sent).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ require 'ffaker'
 require 'aws-sdk'
 require 'selenium-webdriver'
 require 'chromedriver-helper'
+require 'pry'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Ref: #7 
---

| Issue | Migrations? |
| -- | -- |
| #7  |  👎 |

### Todo and done tasks
- Add the inbound shipment order cancel job to parse the SO cancel result document

### Integration
Call the job when an SQS message is received from QL.