### PR TITLE
Replace chromedriver-helper and selenium-helper with webdrivers

### DIFF
--- a/solidus_quiet_logistics.gemspec
+++ b/solidus_quiet_logistics.gemspec
@@ -22,8 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'deface', '~> 1.3'
 
   s.add_development_dependency 'capybara'
-  s.add_development_dependency 'selenium-webdriver'
-  s.add_development_dependency 'chromedriver-helper'
+  s.add_development_dependency 'webdrivers'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'database_cleaner'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,7 @@ require 'rspec/rails'
 require 'database_cleaner'
 require 'ffaker'
 require 'aws-sdk'
-require 'selenium-webdriver'
-require 'chromedriver-helper'
+require 'webdrivers'
 require 'pry'
 
 # Requires supporting ruby files with custom matchers and macros, etc,


### PR DESCRIPTION
chromedriver-helper was deprecated in favour of webdrivers gem