### PR TITLE
Fix QuantityOrdered and QuantityToShip attributes on the SO document

### DIFF
--- a/lib/solidus_quiet_logistics/outbound/document/shipment_order.rb
+++ b/lib/solidus_quiet_logistics/outbound/document/shipment_order.rb
@@ -75,8 +75,8 @@ module SolidusQuietLogistics
                 ship_order.OrderDetails(
                   Line: index,
                   ItemNumber: line_item.sku,
-                  QuantityOrdered: line_item.quantity,
-                  QuantityToShip: line_item.quantity,
+                  QuantityOrdered: quantity(line_item),
+                  QuantityToShip: quantity(line_item),
                   Price: line_item.price,
                   UOM: 'EA',
                 )
@@ -106,6 +106,10 @@ module SolidusQuietLogistics
             shipment.order.created_at.strftime('%Y%m%d'),
             shipment.order.created_at.strftime('%H%M%S'),
           ].join('_').concat('.xml')
+        end
+
+        def quantity(line_item)
+          @shipment.inventory_units.where(variant_id: line_item.variant_id).count
         end
 
         def ship_special_service


### PR DESCRIPTION
Ref: #13 
---

| Issue | Migrations? |
| -- | -- |
| #13 |  👎 |

If there are only 5 stock items for the ordered product, and the requested quantity is 10, the order will be created with 2 shipments.
Each shipment has one line item with quantity set to 10.
The problem is that each shipment is an order for QL so we should take the inventory units count for each shipment instead of the line item quantity otherwise QL will receive double the items to be shipped.