### PR TITLE
Receive and parse RMA document result message

### DIFF
--- a/app/decorators/models/spree/refund_reason/find_or_create_return_processing_reason.rb
+++ b/app/decorators/models/spree/refund_reason/find_or_create_return_processing_reason.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusQuietLogistics
+  module RefundReason
+    module FindOrCreateReturnProcessingReason
+      def self.prepended(base)
+        base.singleton_class.prepend ClassMethods
+      end
+
+      module ClassMethods
+        def return_processing_reason
+          find_or_create_by!(name: 'Return processing', mutable: false)
+        end
+      end
+
+      Spree::RefundReason.prepend self
+    end
+  end
+end

--- a/app/mailers/solidus_quiet_logistics/inbound/rma_mailer.rb
+++ b/app/mailers/solidus_quiet_logistics/inbound/rma_mailer.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module SolidusQuietLogistics
+  module Inbound
+    class RMAMailer < BaseMailer
+      def failed_refund_to_customer(return_authorization, return_items)
+        @return_authorization = return_authorization
+        @return_items = return_items
+
+        mail(
+          to: return_authorization.order.user.email,
+          from: from_address(return_authorization.order.store),
+          subject: t(
+            'quiet_logistics.mailers.failed_refund_to_customer.subject',
+            order_number: return_authorization.order.number,
+          ),
+        )
+      end
+
+      def failed_refund_to_support(return_authorization, return_items)
+        @return_authorization = return_authorization
+        @return_items = return_items
+
+        mail(
+          to: support_email,
+          from: from_address(return_authorization.order.store),
+          subject: t(
+            'quiet_logistics.mailers.failed_refund_to_support.subject',
+            order_number: return_authorization.order.number,
+            return_authorization_number: return_authorization.number,
+          ),
+        )
+      end
+    end
+  end
+end

--- a/app/views/solidus_quiet_logistics/inbound/rma_mailer/_return_items.html.erb
+++ b/app/views/solidus_quiet_logistics/inbound/rma_mailer/_return_items.html.erb
@@ -1,0 +1,13 @@
+<table>
+  <% return_items.each do |return_item| %>
+    <tr>
+      <td><%= return_item.return_authorization.number %></td>
+      <td>
+        <% if return_item.variant.images.any? && return_item.variant.images.first.attachment.present? %>
+          <img src="<%= return_item.variant.images.first.attachment(:mini) %>" />
+        <% end %>
+      </td>
+      <td><%= return_item.inventory_unit.line_item.quantity %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/solidus_quiet_logistics/inbound/rma_mailer/failed_refund_to_customer.html.erb
+++ b/app/views/solidus_quiet_logistics/inbound/rma_mailer/failed_refund_to_customer.html.erb
@@ -1,0 +1,23 @@
+<table>
+  <tr>
+    <td>
+      <p class="lede">
+        <%= t('.dear_customer') %>
+      </p>
+      <p>
+        <%= t('quiet_logistics.mailers.failed_refund_to_customer.title') %>
+      </p>
+      <p>
+        <%= t('quiet_logistics.mailers.failed_refund_to_customer.return_items') %>
+        <span><%= t('mailers.first_name', name: @return_authorization.order.email) %></span>
+        <span><%= t('quiet_logistics.mailers.failed_refund_to_customer.content', refund_amount: @return_items.sum(&:amount)) %></span>
+        <span><%= t('quiet_logistics.mailers.failed_refund_to_support.subcontent') %></span>
+      </p>
+      <%= render 'return_items', return_items: @return_items %>
+      <p>
+        <%= t('.thanks') %>
+      </p>
+    </td>
+    <td class="expander"></td>
+  </tr>
+</table>

--- a/app/views/solidus_quiet_logistics/inbound/rma_mailer/failed_refund_to_support.html.erb
+++ b/app/views/solidus_quiet_logistics/inbound/rma_mailer/failed_refund_to_support.html.erb
@@ -1,0 +1,24 @@
+<table>
+  <tr>
+    <td>
+      <p class="lede">
+        <%= t('.dear_customer') %>
+      </p>
+      <p>
+        <%= t('quiet_logistics.mailers.failed_refund_to_support.title') %>
+      </p>
+      <p>
+        <span><%= t('mailers.first_name.failed_refund_to_support.content',
+          refund_amount: @return_items.sum(&:amount),
+          customer_email: @return_authorization.order.email) %>
+        </span>
+        <span><%= t('quiet_logistics.mailers.failed_refund_to_support.subcontent') %></span>
+      </p>
+      <%= render 'return_items', return_items: @return_items %>
+      <p>
+        <%= t('.thanks') %>
+      </p>
+    </td>
+    <td class="expander"></td>
+  </tr>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,22 @@ en:
         cancellation_date: Cancellation received at %{cancellation_date}
         not_sent: Cancellation not sent
     mailers:
+      failed_refund_to_customer:
+        subject: "Incorrect return item: Order #%{order_number}"
+        title: Incorrect Return Item
+        content: |
+          There was a problem with your return request for: $%{refund_amount}.
+        subcontent: |
+          Please contact our support team clicking the button below.
+        return_items: 'Incorrect return items:'
+      failed_refund_to_support:
+        subject: "Incorrect return item: Order #%{order_number}, RMA #%{return_authorization_number}"
+        title: Incorrect Return Item
+        content: |
+          There was a problem with a return request for: $%{refund_amount} submitted by %{customer_email}.
+        subcontent: |
+          Customer attempted to return the items listed below, but Quiet marked that they received a different item.
+        return_items: 'Incorrect return items:'
       shipment_cancellation_failed:
         title: Shipment cancellation failed
         subtitle: "We can't cancel your shipment: %{shipment_number}"

--- a/db/migrate/20190625073424_add_ql_rma_received_date_to_spree_inventory_unit.rb
+++ b/db/migrate/20190625073424_add_ql_rma_received_date_to_spree_inventory_unit.rb
@@ -1,0 +1,5 @@
+class AddQlRmaReceivedDateToSpreeInventoryUnit < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_inventory_units, :ql_rma_received, :datetime
+  end
+end

--- a/lib/generators/solidus_quiet_logistics/templates/resource/initializer.rb
+++ b/lib/generators/solidus_quiet_logistics/templates/resource/initializer.rb
@@ -1,5 +1,6 @@
 SolidusQuietLogistics.configure do |config|
   config.enabled = -> (order) { true }
+  config.support_email = 'support@example.com'
 
   # Quiet Logistics configuration ( provided by QL )
   config.client_id = 'CLIENT_ID'
@@ -26,4 +27,11 @@ SolidusQuietLogistics.configure do |config|
   # config.order_gift_message = -> (order) do
   #   order.gift_message if order.gift_message?
   # end
+
+  # Return authorization
+  # Default rma correct product statuses.
+  # An RMA will be considered correct if the product status is GOOD or
+  # DAMAGED and incorrect if the product status is INCORRECT.
+  # Here you can change the default behaviour
+  config.rma_correct_product_statuses = ['GOOD', 'DAMAGED']
 end

--- a/lib/solidus_quiet_logistics.rb
+++ b/lib/solidus_quiet_logistics.rb
@@ -12,6 +12,9 @@ class Configuration
 
   # Custom fields
   attr_accessor :order_gift_message, :order_special_service_amount
+
+  # Return authorization
+  attr_accessor :rma_correct_product_statuses
 end
 
 module SolidusQuietLogistics

--- a/lib/solidus_quiet_logistics/inbound/document/rma_result_document.rb
+++ b/lib/solidus_quiet_logistics/inbound/document/rma_result_document.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module SolidusQuietLogistics
+  module Inbound
+    class Document < SolidusQuietLogistics::Document
+      class RMAResultDocument < SolidusQuietLogistics::Inbound::Document
+        class RMAItem
+          attr_reader :line, :number, :quantity, :product_status, :order_number,
+            :notes
+
+          class << self
+            def from_element(line)
+              new(
+                line: line['LineNo'],
+                number: line['ItemNumber'],
+                quantity: line['Quantity'],
+                product_status: line['ProductStatus'],
+                order_number: line['OrderNumber'],
+                notes: line['Notes'],
+              )
+            end
+          end
+
+          def initialize(line:, number:, quantity:, product_status:,
+            order_number:, notes: '')
+
+            @line = line
+            @number = number
+            @quantity = quantity
+            @product_status = product_status
+            @order_number = order_number
+            @notes = notes
+          end
+
+          def correct?
+            correct_statuses = SolidusQuietLogistics.configuration&.rma_correct_product_statuses || []
+            correct_statuses.any? { |status| status == product_status }
+          end
+        end
+
+        class << self
+          def from_xml(body)
+            nokogiri = Nokogiri::XML(body)
+            items = nokogiri.css('Line').map { |line| RMAItem.from_element(line) }
+
+            new(
+              rma_number: nokogiri.xpath('//@RMANumber').first.text,
+              rma_items: items,
+            )
+          end
+        end
+
+        attr_reader :return_authorization, :rma_items
+
+        def initialize(rma_number:, rma_items: [])
+          @return_authorization = Spree::ReturnAuthorization.find_by(number: rma_number)
+          @rma_items = rma_items
+        end
+
+        def process
+          return unless return_authorization
+
+          correct_items = rma_items.select(&:correct?)
+          incorrect_items = rma_items - correct_items
+
+          refund_customer(correct_items)
+          notify_support_team(incorrect_items)
+        end
+
+        private
+
+        def return_authorization_items(return_items)
+          return_items.flat_map do |item|
+            return_authorization.return_items
+              .where(acceptance_status: 'pending')
+              .joins(inventory_unit: :variant)
+              .where(spree_variants: { sku: item.number }).limit(item.quantity)
+          end
+        end
+
+        def refund_customer(correct_items)
+          return_items = return_authorization_items(correct_items)
+          return if return_items.empty?
+
+          customer_return = Spree::CustomerReturn.create!(
+            stock_location: return_authorization.stock_location,
+            return_items: return_items,
+          )
+
+          return_items.each do |return_item|
+            return_item.receive
+            return_item.inventory_unit.update!(ql_rma_received: Time.zone.now)
+          end
+
+          begin
+            Spree::Reimbursement.create!(
+              order: return_authorization.order,
+              customer_return: customer_return,
+              return_items: return_items,
+            ).return_all(created_by: return_authorization.order.user)
+          rescue Spree::Reimbursement::IncompleteReimbursementError => e
+            Rails.logger.info e.message
+          end
+        end
+
+        def notify_support_team(incorrect_items)
+          return_items = return_authorization_items(incorrect_items)
+          return if return_items.all?(&:blank?)
+
+          return_items.each do |return_item|
+            return_item.inventory_unit.update!(ql_rma_sent: nil)
+          end
+
+          SolidusQuietLogistics::Inbound::RMAMailer
+            .failed_refund_to_customer(
+              return_authorization,
+              return_items,
+            )
+            .deliver_later
+
+          SolidusQuietLogistics::Inbound::RMAMailer
+            .failed_refund_to_support(
+              return_authorization,
+              return_items,
+            )
+            .deliver_later
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_quiet_logistics/inbound/message_processor.rb
+++ b/lib/solidus_quiet_logistics/inbound/message_processor.rb
@@ -6,8 +6,8 @@ module SolidusQuietLogistics
       DOCUMENT_CLASSES = {
         'ShipmentOrderResult' => Document::ShipmentOrderResult,
         'ShipmentOrderCancelReady' => Document::ShipmentOrderCancelReady,
+        'RMAResultDocument' => Document::RMAResultDocument,
         # 'InventorySummaryReady' => Document::InventorySummaryReady,
-        # 'RMAResultDocument' => Document::RMAResultDocument,
         # 'ProductConfigurationRequest' => Document::ProductConfigurationRequest,
         # 'PurchaseOrderStartReceipt' => Document::PurchaseOrderStartReceipt,
         # 'PurchaseOrderReceipt' => Document::PurchaseOrderReceipt,

--- a/spec/mailers/solidus_quiet_logistics/inbound/rma_mailer_spec.rb
+++ b/spec/mailers/solidus_quiet_logistics/inbound/rma_mailer_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusQuietLogistics::Inbound::RMAMailer, type: :mailer do
+  let(:support_email) { 'support@example.com' }
+
+  let(:return_authorization) { create(:return_authorization) }
+  let(:return_items) do
+    [
+      create(:return_item, return_authorization: return_authorization),
+      create(:return_item, return_authorization: return_authorization),
+    ]
+  end
+
+  before do
+    allow(SolidusQuietLogistics.configuration).to receive(:support_email)
+      .and_return(support_email)
+  end
+
+  describe '.failed_refund_to_customer' do
+    let(:mail) { described_class.failed_refund_to_customer(return_authorization, return_items) }
+
+    it 'sends the email to the user' do
+      expect(mail.to).to eq([return_authorization.order.user.email])
+    end
+  end
+
+  describe '.failed_refund_to_support' do
+    let(:mail) { described_class.failed_refund_to_support(return_authorization, return_items) }
+
+    it 'sends the email to the support email' do
+      expect(mail.to).to eq([support_email])
+    end
+  end
+end

--- a/spec/models/spree/refund_reason_spec.rb
+++ b/spec/models/spree/refund_reason_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::RefundReason do
+  describe '.return_processing_reason' do
+    context 'when the return processing reason doesn\'t exist' do
+      it 'creates return processing reason' do
+        described_class.return_processing_reason
+
+        expect(described_class.count).to eq(1)
+        expect(described_class.first.name).to eq('Return processing')
+      end
+    end
+
+    context 'when return processing reason exist' do
+      let!(:refund_reason) { create(:refund_reason, name: 'Return processing', mutable: false) }
+
+      it 'returns it' do
+        described_class.return_processing_reason
+
+        expect(described_class.first).to eq(refund_reason)
+      end
+    end
+  end
+end

--- a/spec/solidus_quiet_logistics/inbound/document/rma_result_document_spec.rb
+++ b/spec/solidus_quiet_logistics/inbound/document/rma_result_document_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusQuietLogistics::Inbound::Document::RMAResultDocument do
+  let(:correct_rma_dict) do
+    {
+      line: '1',
+      number: '050-00400',
+      quantity: '1',
+      product_status: 'GOOD',
+      order_number: 'R123456789-1',
+      notes: 'This is a note',
+    }
+  end
+
+  let(:damaged_rma_dict) do
+    {
+      line: '2',
+      number: '050-00400',
+      quantity: '2',
+      product_status: 'DAMAGED',
+      order_number: 'R123456789-1',
+      notes: '',
+    }
+  end
+
+  let(:incorrect_rma_dict) do
+    {
+      line: '3',
+      number: '050-00400',
+      quantity: '1',
+      product_status: 'INCORRECT',
+      order_number: 'R123456789-1',
+      notes: '',
+    }
+  end
+
+  describe '.from_xml' do
+    subject(:document) { described_class.from_xml(xml) }
+
+    let(:xml) { read_ql_document(:rma_result_document) }
+
+    it 'parses the rma items' do
+      expect(parse_items(document)).to match_array([correct_rma_dict, damaged_rma_dict, incorrect_rma_dict])
+    end
+
+    def parse_items(document)
+      document.rma_items.map do |item|
+        {
+          line: item.line,
+          number: item.number,
+          quantity: item.quantity,
+          product_status: item.product_status,
+          order_number: item.order_number,
+          notes: item.notes,
+        }
+      end
+    end
+  end
+
+  describe '#process' do
+    subject(:document) do
+      described_class.new(
+        rma_number: return_authorization_number,
+        rma_items: [
+          described_class::RMAItem.new(correct_rma_dict),
+          described_class::RMAItem.new(damaged_rma_dict),
+          described_class::RMAItem.new(incorrect_rma_dict),
+        ],
+      )
+    end
+
+    let(:order) { create(:shipped_order) }
+
+    let(:return_authorization) { create(:return_authorization, order: order) }
+    let(:return_authorization_number) { return_authorization.number }
+
+    let(:variant) { create(:variant, sku: '050-00400') }
+
+    let!(:good_return_item) { create(:return_item, return_authorization: return_authorization) }
+    let!(:damaged_return_item) { create(:return_item, return_authorization: return_authorization) }
+    let!(:incorrect_return_item) { create(:return_item, return_authorization: return_authorization) }
+
+    let(:rma_document_to_customer_mailer) { instance_double('ActionMailer::Delivery') }
+    let(:rma_document_to_suppport_mailer) { instance_double('ActionMailer::Delivery') }
+
+    before do
+      allow(SolidusQuietLogistics::Inbound::RMAMailer).to receive(:failed_refund_to_customer)
+        .and_return(rma_document_to_customer_mailer)
+
+      allow(SolidusQuietLogistics::Inbound::RMAMailer).to receive(:failed_refund_to_support)
+        .and_return(rma_document_to_suppport_mailer)
+
+      return_authorization.reload.return_items.map do |return_item|
+        return_item.inventory_unit.update_attributes(variant: variant)
+        return_item.shipment.update_attributes(order: order)
+      end
+    end
+
+    it 'refunds the correct return items and sends an email to the support for the incorrect return items' do
+      expect(rma_document_to_customer_mailer).to receive(:deliver_later)
+      expect(rma_document_to_suppport_mailer).to receive(:deliver_later)
+
+      document.process
+
+      expect(order.reimbursements.first.reimbursement_status).to eq('reimbursed')
+      expect(good_return_item.reload.reception_status).to eq('received')
+      expect(damaged_return_item.reload.reception_status).to eq('received')
+      expect(incorrect_return_item.reload.reception_status).to eq('awaiting')
+
+      expect(good_return_item.inventory_unit.ql_rma_received).to be_present
+      expect(damaged_return_item.inventory_unit.ql_rma_received).to be_present
+      expect(incorrect_return_item.inventory_unit.ql_rma_sent).not_to be_present
+
+      expect(return_authorization.customer_returns.uniq.count).to eq(1)
+      expect(return_authorization.customer_returns.first.reimbursements.count).to eq(1)
+    end
+
+    context 'when rma_number is wrong' do
+      let(:return_authorization_number) { 'Wrong rma number' }
+
+      it 'doesn\'t refunt the return items and doesn\'t send the email to the support' do
+        expect(rma_document_to_customer_mailer).not_to receive(:deliver_later)
+        expect(rma_document_to_suppport_mailer).not_to receive(:deliver_later)
+
+        document.process
+
+        expect(order.reimbursements.count).to eq(0)
+        expect(good_return_item.reload.reception_status).to eq('awaiting')
+        expect(damaged_return_item.reload.reception_status).to eq('awaiting')
+        expect(incorrect_return_item.reload.reception_status).to eq('awaiting')
+      end
+    end
+
+    context 'when rma_items are all correct' do
+      subject(:document) do
+        described_class.new(
+          rma_number: return_authorization_number,
+          rma_items: [
+            described_class::RMAItem.new(correct_rma_dict),
+            described_class::RMAItem.new(damaged_rma_dict),
+          ],
+        )
+      end
+
+      it 'refunds the correct return items' do
+        expect(rma_document_to_customer_mailer).not_to receive(:deliver_later)
+        expect(rma_document_to_suppport_mailer).not_to receive(:deliver_later)
+
+        document.process
+
+        expect(order.reimbursements.first.reimbursement_status).to eq('reimbursed')
+        expect(good_return_item.reload.reception_status).to eq('received')
+        expect(damaged_return_item.reload.reception_status).to eq('received')
+      end
+    end
+
+    context 'when rma_items are all incorrect' do
+      subject(:document) do
+        described_class.new(
+          rma_number: return_authorization_number,
+          rma_items: [
+            described_class::RMAItem.new(incorrect_rma_dict),
+          ],
+        )
+      end
+
+      it 'does not refund any items' do
+        expect(rma_document_to_customer_mailer).to receive(:deliver_later)
+        expect(rma_document_to_suppport_mailer).to receive(:deliver_later)
+
+        document.process
+
+        expect(order.reimbursements.count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/support/attribute_setup.rb
+++ b/spec/support/attribute_setup.rb
@@ -9,4 +9,6 @@ SolidusQuietLogistics.configure do |config|
   config.aws_region = 'aws_region'
   config.aws_outbox_queue_url = 'aws_outbox_queue_url'
   config.aws_outbox_bucket = 'aws_outbox_bucket'
+
+  config.rma_correct_product_statuses = ['GOOD', 'DAMAGED']
 end

--- a/spec/support/files/solidus_quiet_logistics/documents/rma_result_document.xml
+++ b/spec/support/files/solidus_quiet_logistics/documents/rma_result_document.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RMAResultDocument
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://schemas.quietlogistics.com/V2/RMAResultDocument.xsd">
+  <RMAResult ClientID="QUIET" BusinessUnit="QUIET" RMANumber="RA740246728" ReceiptDate="2018-09-24T12:18:48.1294776Z" Warehouse="CORP1">
+    <Line LineNo="1" ItemNumber="050-00400" ReturnUOM="EA" Quantity="1" ProductStatus="GOOD" Notes="This is a note" OrderNumber="R123456789-1" />
+    <Line LineNo="2" ItemNumber="050-00400" ReturnUOM="EA" Quantity="2" ProductStatus="DAMAGED" Notes="" OrderNumber="R123456789-1" />
+    <Line LineNo="3" ItemNumber="050-00400" ReturnUOM="EA" Quantity="1" ProductStatus="INCORRECT" Notes="" OrderNumber="R123456789-1" />
+  </RMAResult>
+</RMAResultDocument>


### PR DESCRIPTION
Ref: #15 
---

| Issue | Migrations? |
| -- | -- |
| #15  | 👍 |

### Todo and done tasks
- Receive and parse RMA document result message

### Integration
Create an RMA from the Solidus admin panel

Parse the RMA document result, create a customer return with the same 
inventory units and refund the customer with the correct or damaged 
items.
Send an email to the support and another one to the customer for each 
incorrect item.